### PR TITLE
Bugfix: Vertical swipe gesture on the navigation bar locks entire application.

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -358,6 +358,7 @@ const int FrontViewPositionNone = 0xff;
     _frontViewShadowRadius = 2.5f;
     _frontViewShadowOffset = CGSizeMake(0.0f, 2.5f);
     _animationQueue = [NSMutableArray array];
+    _userInteractionStore = YES;
 }
 
 


### PR DESCRIPTION
Issue: https://github.com/John-Lluch/SWRevealViewController/issues/27

I've made a change proposed by wjlandryiii. And it works for me. I cannot freeze the app anymore.
