### PR TITLE
Add podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A UIViewController subclass for revealing a rear (left and/or right) view contro
 
 ## Requirements
 
-* iOS 6.0 or later.
+* iOS 5.1 or later.
 * ARC memory management.
 
 ## Usage

--- a/SWRevealViewController.podspec
+++ b/SWRevealViewController.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license       = "MIT"
   s.author        = { "John Lluch Zorrilla" => "joan.lluch@sweetwilliamsl.com" }
   s.source        = { :git => "https://github.com/John-Lluch/SWRevealViewController.git", :tag =>  "v#{s.version}" }
-  s.platform      = :ios, "6.0"
+  s.platform      = :ios, "5.1"
   s.source_files  = "SWRevealViewController/*.{h,m}"
   s.framework     = "CoreGraphics"
   s.requires_arc  = true


### PR DESCRIPTION
This adds the latest version of the podspec to the repo. Additionally, if you could please provide a `v1.0.5` tag for the latest iOS 7 beta 3 changes, the podspec can be updated to support those.
