### PR TITLE
Fix for black screen when only right view is needed and no back view is ...

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -473,15 +473,29 @@ static NSString * const SWSegueRightIdentifier = @"sw_right";
     // load any defined front/rear controllers from the storyboard
     if ( self.storyboard && _rearViewController == nil )
     {
+        //Try each segue separately so it doesn't break prematurely if either Rear or Right views are not used.
         @try
         {
             [self performSegueWithIdentifier:SWSegueRearIdentifier sender:nil];
+        }
+        @catch(NSException *exception)
+        {
+        }
+        
+        @try
+        {
             [self performSegueWithIdentifier:SWSegueFrontIdentifier sender:nil];
+        }
+        @catch(NSException *exception)
+        {
+        }
+        
+        @try
+        {
             [self performSegueWithIdentifier:SWSegueRightIdentifier sender:nil];
         }
         @catch(NSException *exception)
         {
-            //NSLog(@"Caught %@: %@", [exception name], [exception reason]);
         }
     }
     


### PR DESCRIPTION
...present (when using storyboard).

I was using a storyboard with the sw_right segue to define the right view and sw_front for the front. But all I was getting was a black screen. This is because that try catch block is all in one. So when sw_back fails (if its not needed like in my case) the following two views fail to load too. 

I split up the try catches which fixes the problem and allows any combination of views that you want.
