### PR TITLE
Implement swipe to delete in UITableViewCell's fix

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -848,6 +848,9 @@ static NSString * const SWSegueRightIdentifier = @"sw_right";
     return draggableBorderAllowing ;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
+}
 
 #pragma mark - Gesture Based Reveal
 


### PR DESCRIPTION
Swipe to delete for UITableViewCell's is broken.  This issue is easy to replicate by creating a UIView with a UITableView.  Then add the gesture recognizer to the view.

```
SWRevealViewController *revealController = [self revealViewController];

[self.view addGestureRecognizer:revealController.panGestureRecognizer];
```

Swipe to delete for UITableViewCell's is then broken.

This pull request also fixes this reported issue:
https://github.com/John-Lluch/SWRevealViewController/issues/104

More discussion here:
http://stackoverflow.com/questions/18369844/get-swipe-to-delete-on-uitableview-to-work-with-uipangesturerecognizer
