### PR TITLE
The gestureRecognizers should not be automatically added to the frontView

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The easiest way to install it is by copying the following to your project:
 * Optionaly add a "right" view controller or pass nil as the "rear" view controller.
 * Use the SWRevealViewController instance in your code as you would use any view controller.
 * Deploy as the application window rootViewController, or as a child of other containment controllers.
-* Get the panGestureRecognized and tapGestureRecognizer provided by the SWRevealViewController. You can leave them as they are for the default behavior or you can add them to a suitable view on your "front" view controller. For example add the panGestureRecognizer to a navigationBar on the viewDidLoad method of your front controller.
+* Get the panGestureRecognized and tapGestureRecognizer provided by the SWRevealViewController. You can add them to a suitable view on your "front" view controller. For example add the panGestureRecognizer to a navigationBar on the viewDidLoad method of your front controller.
 * At any time, you can reveal, conceal the "rear" or "right" views or replace any of the view controllers, programmatically or based on user actions, with or without animations enabled
 
 ## Basic API Description

--- a/RevealControllerExample/RevealControllerProject/FrontViewController.m
+++ b/RevealControllerExample/RevealControllerProject/FrontViewController.m
@@ -48,8 +48,8 @@
     SWRevealViewController *revealController = [self revealViewController];
     
     
-    [revealController panGestureRecognizer];
-    [revealController tapGestureRecognizer];
+    [self.view addGestureRecognizer:[revealController panGestureRecognizer]];
+    [self.view addGestureRecognizer:[revealController tapGestureRecognizer]];
     
     UIBarButtonItem *revealButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"reveal-icon.png"]
         style:UIBarButtonItemStyleBordered target:revealController action:@selector(revealToggle:)];

--- a/SWRevealViewController/SWRevealViewController.h
+++ b/SWRevealViewController/SWRevealViewController.h
@@ -151,14 +151,10 @@ typedef enum
 // The following method will provide a panGestureRecognizer suitable to be added to any view
 // in order to perform usual drag and swipe gestures to reveal the rear views. This is usually added to the top bar
 // of a front controller, but it can be added to your frontViewController view or to the reveal controller view to provide full screen panning.
-// The provided panGestureRecognizer is initially added to the reveal controller's front container view, so you can dissable
-// user interactions on your controllers views and the recognizer will continue working. 
 - (UIPanGestureRecognizer*)panGestureRecognizer;
 
 // The following method will provide a tapGestureRecognizer suitable to be added to any view on the frontController
-// for concealing the rear views. By default no tap recognizer is created or added to any view, however if you call this method after
-// the controller's view has been loaded the recognizer is added to the reveal controller's front container view.
-// Thus, you can disable user interactions on your frontViewController view without affecting the tap recognizer.
+// for concealing the rear views.
 - (UITapGestureRecognizer*)tapGestureRecognizer;
 
 // The following properties are provided for further customization, they are set to default values on initialization,

--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -694,8 +694,10 @@ static NSString * const SWSegueRightIdentifier = @"sw_right";
         
         panRecognizer.direction = SWDirectionPanGestureRecognizerHorizontal;
         panRecognizer.delegate = self;
-        [_contentView.frontView addGestureRecognizer:panRecognizer];
-        _panGestureRecognizer = panRecognizer ;
+        _panGestureRecognizer = panRecognizer;
+		
+		// Do not automatically add gestureRecognizer to any views.
+		// This should be done explicitly by the user if they want it.
     }
     return _panGestureRecognizer;
 }
@@ -709,8 +711,10 @@ static NSString * const SWSegueRightIdentifier = @"sw_right";
             [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(_handleTapGesture:)];
         
         tapRecognizer.delegate = self;
-        [_contentView.frontView addGestureRecognizer:tapRecognizer];
         _tapGestureRecognizer = tapRecognizer ;
+		
+		// Do not automatically add gestureRecognizer to any views.
+		// This should be done explicitly by the user if they want it.
     }
     return _tapGestureRecognizer;
 }


### PR DESCRIPTION
I understand the desire to have a "good default behavior", but the current solution comes at the expense of confusion and inconsistency. I will argue that the alternative is more consistent and understandable:

_Why the gestureRecognizers should not be automatically added to the frontView:_

First, this is not something one would expect to happen by simply invoking a method to get a gestureRecognizer, comments notwithstanding. Second, the gestureRecognizers are not automatically added to _all_ frontViews. Only the current frontView at the time the method is first called. This leads to confusion, as developers might wonder why the gestureRecognizers stop working when they set a different frontViewController. Additionally, if the developer does not want to add the gestureRecognizers to the frontView, then there is no way to fetch the gestureRecognizers without having them get added. This forces the developer to fetch the gestureRecognizers, and then immediately turn around and remove them from the frontView. Ultimately not adding them by default provides a more consistent routine: fetch the gestureRecognizer(s) and add them to every place I want, most often in viewDidLoad.

One of the things I like about this library is that it doesn't try to do everything. It does exactly what one would expect, and then explains what developers need to do themselves in order to get features Y & Z. However, I feel that the default gestureRecognizer behavior is in violation of this principle that otherwise permeates the framework. Providing a gestureRecognizer (and delegates), and then telling developers to properly add them where needed seems, to me, more in line with the work as a whole.
