### PR TITLE
Resolve Xcode 7.1 errors

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -762,7 +762,11 @@ const int FrontViewPositionNone = 0xff;
 }
 
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 10000
 - (NSUInteger)supportedInterfaceOrientations
+#else
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+#endif
 {
     // we could have simply not implemented this, but we choose to call super to make explicit that we
     // want the default behavior.


### PR DESCRIPTION
Resolving issues with Xcode 7.1

“…/SWRevealViewController.m:765:1: Conflicting return type in
implementation of 'supportedInterfaceOrientations':
'UIInterfaceOrientationMask' (aka 'enum UIInterfaceOrientationMask') vs
'NSUInteger' (aka 'unsigned long’)”

---

Changed code to fit actual settings with #504 
