### PR TITLE
Update SWRevealViewController.m

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -762,7 +762,7 @@ const int FrontViewPositionNone = 0xff;
 }
 
 
-- (NSUInteger)supportedInterfaceOrientations
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     // we could have simply not implemented this, but we choose to call super to make explicit that we
     // want the default behavior.


### PR DESCRIPTION
Fixed the following warning message: Conflicting return type in implementation of supportedInterfaceOrientations: UIinterfaceOrientationMask (aka enum UIinterfaceOrientationMask vs NSUIinteger (aka unsigned int)).
