### PR TITLE
Fix Xcode 10 warning: UIViewControllerContextTransitioning protocol c…

### DIFF
--- a/SWRevealViewController/SWRevealViewController.m
+++ b/SWRevealViewController/SWRevealViewController.m
@@ -432,6 +432,12 @@ static CGFloat scaledValue( CGFloat v1, CGFloat min2, CGFloat max2, CGFloat min1
 }
 
 
+- (void)pauseInteractiveTransition
+{
+    // not supported
+}
+
+
 - (void)finishInteractiveTransition
 {
     // not supported


### PR DESCRIPTION
At some point along the way Apple added a `pauseInteractiveTransition` method to the `UIViewControllerContextTransitioning` protocol.  Doesn't seem to hurt anything that it's missing, but just to fix the warning...